### PR TITLE
Add missing Gutenberg dependencie and import WXR

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -5,47 +5,19 @@
         "php": "8.0",
         "wp": "latest"
     },
-    "phpExtensionBundles": [
-        "kitchen-sink"
-    ],
     "features": {
-        "networking": true
+    "networking": true
     },
+    "plugins": [
+        "pdf-embed",
+        "gutenberg",
+        "formello",
+        "popper"
+    ],
     "steps": [
         {
-            "step": "installPlugin",
-            "pluginZipFile": {
-                "resource": "url",
-                "url": "https:\/\/downloads.wordpress.org\/plugin\/pdf-embed.zip"
-            },
-            "options": {
-                "activate": true
-            }
-        },
-        {
-            "step": "installPlugin",
-            "pluginZipFile": {
-                "resource": "url",
-                "url": "https:\/\/downloads.wordpress.org\/plugin\/formello.zip"
-            },
-            "options": {
-                "activate": true
-            }
-        },
-        {
-            "step": "installPlugin",
-            "pluginZipFile": {
-                "resource": "url",
-                "url": "https:\/\/downloads.wordpress.org\/plugin\/popper.zip"
-            },
-            "options": {
-                "activate": true
-            }
-        },
-        {
             "step": "login",
-            "username": "admin",
-            "password": "password"
+            "username": "admin"
         },
         {
             "step": "setSiteOptions",
@@ -54,7 +26,7 @@
             }
         },
         {
-            "step": "importFile",
+            "step": "importWxr",
             "file": {
                 "resource": "url",
                 "url": "https://raw.githubusercontent.com/tropicalista/pdf-embed/master/.playground/demo-content.xml"


### PR DESCRIPTION
@Tropicalista I noticed that [your WordPress.org preview ](https://wordpress.org/plugins/pdf-embed/) was broken and would like to contribute a fix.

The PR adds the missing Gutenberg dependency, which is why your preview isn't loading.
Plugins are loaded [using the `plugins` shorthand](https://wordpress.github.io/wordpress-playground/guides/for-plugin-developers/#plugins) just to make the Blueprint smaller, but it would also work [with the `installPlugin` steps.](https://wordpress.github.io/wordpress-playground/blueprints/steps/#InstallPluginStep)

I noticed that you are loading a WXR in the Blueprint, so I added [an `importWxr` step](https://wordpress.github.io/wordpress-playground/blueprints/steps#ImportWxrStep) to import the file. 
This also makes post 6 available and `"landingPage": "/wp-admin/post.php?post=6&action=edit"` will load correctly. 